### PR TITLE
Add automatic vMix Server Reconnect

### DIFF
--- a/src/a_GLOBAL/a_GLOBAL.ino
+++ b/src/a_GLOBAL/a_GLOBAL.ino
@@ -23,9 +23,11 @@ void setupmatrix() {
   matrix.fillScreen(matrix.Color(0,0,0));
   }
 
+int tnlen = 1; //LET THIS BE
+
 Preferences preferences;
 
-//DON'T CHANGE THESE VARIABLES, YOU CAN CHANGE THEM IN THE WEB UI
+//DON'T CHANGE THESE VARIABLES, YOU CAN CHANGE THEM IN THE WEB UI - Unless otherwise noted;)
 String WIFI_SSID = "";
 String WIFI_PASS = "";
 String VMIX_IP = "";
@@ -33,3 +35,4 @@ String M_TALLY = "";
 int VMIX_PORT = 8099; //USES THE TCP API PORT, THIS IS FIXED IN VMIX
 int TALLY_NR = 1;
 int BRIGHTNESS = 12; //100%
+int CONN_INT = 10; // Change this to how long the M5 should wait before attempting to reconnect to the VMIX server.

--- a/src/a_GLOBAL/b_SETTINGS.ino
+++ b/src/a_GLOBAL/b_SETTINGS.ino
@@ -17,7 +17,11 @@ void loadSettings()
   if(preferences.getString("vmix_ip").length() > 0){
     TALLY_NR = preferences.getUInt("tally");
     VMIX_IP = preferences.getString("vmix_ip");
-  }
+	    if(TALLY_NR > 9){ 	
+      tnlen = 2;  	
+    } 	
+  } 	
+  CONN_INT = preferences.getUInt("conn_int") || CONN_INT;
 
   if(preferences.getString("m_tally").length() > 0){
     M_TALLY = preferences.getString("m_tally");

--- a/src/a_GLOBAL/c_MAIN.ino
+++ b/src/a_GLOBAL/c_MAIN.ino
@@ -18,6 +18,7 @@ int interval = 5000;
 unsigned long lastCheck = 0;
 unsigned long lastBattCheck = 0;
 unsigned long lastAccCheck = 0;
+unsigned long lastConnCheck = 0;
 int screenRotation = 3;
 
 float accX = 0;
@@ -204,6 +205,13 @@ matrix.show();
     }
   }
   
+    if (CONN_INT != 0 && !client.connected() && !apEnabled && millis() > lastConnCheck + (CONN_INT * 1000))  
+  { 
+    client.stop();  
+    Serial.println("Reconnecting, based on given interval");  
+    singleReconnect();  
+  }
+  
   if (!client.connected() && !apEnabled && millis() > lastCheck + interval)
   {
     client.stop();
@@ -230,6 +238,7 @@ void start()
   M5.Lcd.println("vMix M5Stick-C Tally");
   M5.Lcd.setCursor(35, 40);
   M5.Lcd.println("by Guido Visser");
+    //matrix.setRotation(1); // Uncomment this to rotate the Matrix Display
     matrix.setTextColor(matrix.Color(0,255,0));
     matrix.setTextWrap(false);
     matrix.print("P");

--- a/src/a_GLOBAL/d_VMIX.ino
+++ b/src/a_GLOBAL/d_VMIX.ino
@@ -50,6 +50,22 @@ boolean connectTovMix(bool recursive){
   }
 }
 
+void singleReconnect(){ 
+  resetScreen();  
+  M5.Lcd.println("Connecting to vMix...");  
+  if (client.connect(&(VMIX_IP[0]), VMIX_PORT)) 
+  { 
+    lastConnCheck = millis(); 
+    connectedTovMix = true; 
+    M5.Lcd.println("Connected to vMix!"); 
+    // Subscribe to the tally events  
+    client.println("SUBSCRIBE TALLY");  
+    showTallyScreen();  
+  } else {  
+    lastConnCheck = millis(); 
+  } 
+}
+
 boolean retryConnectionvMix(int tryCount) {
   cls();
   M5.Lcd.setTextSize(1);


### PR DESCRIPTION
Implemented automatic vMix server reconnect on connection loss, pulled from Visser's original code.

Currently the web interface has NOT been updated to change the reconnection interval, so it will have to be manually changed in the code. Currently set to 10 (seconds), and changing this to 0 disables the function entirely. Updating the web interface shouldn't be too difficult, however.

A line has also been added in c_Main that allows the user to rotate the matrix display (this is currently manual only, the IMU sensor function has not been implemented yet in this code for the Matrix). This line is commented out by default.